### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- Migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- Keep the existing `prConcurrentLimit: 5` setting unchanged

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

## Notes
- This is a narrow config-only cleanup for the open Dependency Dashboard config migration item (#1).
- I did not run `atmos test run` because this repository's AGENTS.md notes Terratest deploys real AWS resources and may incur AWS costs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use recommended settings.

---

**Note:** This is an internal configuration update with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->